### PR TITLE
Many upgrades to lifebar.go to include bg/top layer rendering for fight.def entities + bugfixes for Guard/Stunbar + TeamSide-Enabled Action Calls + TOO MUCH TO LIST!!!

### DIFF
--- a/data/action.zss
+++ b/data/action.zss
@@ -8,7 +8,11 @@ if !Const(Default.Enable.Action) || TeamSide = 0 {
 } else if IsHelper {
 	# Parry
 	ignorehitpause if HelperName = "Parry Detection" && MoveHit = 1 {
-		LifebarAction{spr: Const(MsgParry), 0}
+		if TeamSide = 1 {
+			LifebarAction{spr: Const(MsgParry), 0}
+		else if TeamSide = 2 {
+			LifebarAction{spr: Const(MsgParry), 0}
+		}
 	}
 } else if RoundState = 0 {
 	MapSet{map: "_iksys_actionFirstAttackFlag"; value: 0}
@@ -22,40 +26,59 @@ if !Const(Default.Enable.Action) || TeamSide = 0 {
 	MapSet{map: "_iksys_actionWinFlag"; value: 0}
 } else if RoundState >= 2 {
 	# First Attack
-	if FirstAttack && Map(_iksys_actionFirstAttackFlag) = 0 {
+	if FirstAttack && Map(_iksys_actionFirstAttackFlag) = 0 && TeamSide = 1 {
+		LifebarAction{spr: Const(MsgFirstAttack), 0}
+		MapSet{map: "_iksys_actionFirstAttackFlag"; value: 1}
+	} else if FirstAttack && Map(_iksys_actionFirstAttackFlag) = 0 && TeamSide = 2 {
 		LifebarAction{spr: Const(MsgFirstAttack), 0}
 		MapSet{map: "_iksys_actionFirstAttackFlag"; value: 1}
 	}
 	# Counter Hit
-	if MoveCountered = 1 && Map(_iksys_actionMoveCounteredFlag) = 0 {
+	if MoveCountered = 1 && Map(_iksys_actionMoveCounteredFlag) = 0 && TeamSide = 1 {
+		LifebarAction{spr: Const(MsgCounterHit), 0}
+		MapSet{map: "_iksys_actionMoveCounteredFlag"; value: 1}
+	} else if MoveCountered = 1 && Map(_iksys_actionMoveCounteredFlag) = 0 && TeamSide = 2 {
 		LifebarAction{spr: Const(MsgCounterHit), 0}
 		MapSet{map: "_iksys_actionMoveCounteredFlag"; value: 1}
 	} else if MoveCountered = 0 && Map(_iksys_actionMoveCounteredFlag) = 1 {
 		MapSet{map: "_iksys_actionMoveCounteredFlag"; value: 0}
 	}
 	# Technical
-	if CanRecover && StateNo = [Const(StateAirGetHit_fallRecoveryOnGroundStillFalling), Const(StateAirGetHit_fallRecoveryInAir)] && Map(_iksys_actionCanRecoverFlag) = 0 {
+	if CanRecover && StateNo = [Const(StateAirGetHit_fallRecoveryOnGroundStillFalling), Const(StateAirGetHit_fallRecoveryInAir)] && Map(_iksys_actionCanRecoverFlag) = 0 && TeamSide = 1{
+		LifebarAction{spr: Const(MsgTechnical), 0}
+		MapSet{map: "_iksys_actionCanRecoverFlag"; value: 1}
+	} else if CanRecover && StateNo = [Const(StateAirGetHit_fallRecoveryOnGroundStillFalling), Const(StateAirGetHit_fallRecoveryInAir)] && Map(_iksys_actionCanRecoverFlag) = 0 && TeamSide = 2 {
 		LifebarAction{spr: Const(MsgTechnical), 0}
 		MapSet{map: "_iksys_actionCanRecoverFlag"; value: 1}
 	} else if !CanRecover && Map(_iksys_actionCanRecoverFlag) = 1 {
 		MapSet{map: "_iksys_actionCanRecoverFlag"; value: 0}
 	}
 	# Reversal
-	if MoveReversed = 1 {
+	if MoveReversed = 1 && TeamSide = 1 {
+		LifebarAction{spr: Const(MsgReversal), 0; redirectid: enemy,ID}
+	} else if MoveReversed = 1 && TeamSide = 2 {
 		LifebarAction{spr: Const(MsgReversal), 0; redirectid: enemy,ID}
 	}
 	# Hit Overridden (Parry)
-	if HitOverridden {
+	if HitOverridden && TeamSide = 1 {
+		#LifebarAction{spr: Const(MsgParry), 0}
+	} else if HitOverridden && TeamSide = 2 {
 		#LifebarAction{spr: Const(MsgParry), 0}
 	}
 	# Danger
-	if Life > 0 && float(Life) / LifeMax <= 0.3 && Map(_iksys_actionDangerFlag) = 0 {
+	if Life > 0 && float(Life) / LifeMax <= 0.3 && Map(_iksys_actionDangerFlag) = 0 && TeamSide = 1 {
+		LifebarAction{spr: Const(MsgDanger), 0; timemul: 2}
+		MapSet{map: "_iksys_actionDangerFlag"; value: 1}
+	} else if Life > 0 && float(Life) / LifeMax <= 0.3 && Map(_iksys_actionDangerFlag) = 0 && TeamSide = 2 {
 		LifebarAction{spr: Const(MsgDanger), 0; timemul: 2}
 		MapSet{map: "_iksys_actionDangerFlag"; value: 1}
 	}
 	# Dizzy
 	if Dizzy {
-		if Map(_iksys_actionDizzyFlag) = 0 {
+		if Map(_iksys_actionDizzyFlag) = 0 && TeamSide = 1 {
+			LifebarAction{spr: Const(MsgDizzy), 0; timemul: 2}
+			MapSet{map: "_iksys_actionDizzyFlag"; value: 1}
+		} else if Map(_iksys_actionDizzyFlag) = 0 && TeamSide = 2 {
 			LifebarAction{spr: Const(MsgDizzy), 0; timemul: 2}
 			MapSet{map: "_iksys_actionDizzyFlag"; value: 1}
 		}
@@ -64,7 +87,10 @@ if !Const(Default.Enable.Action) || TeamSide = 0 {
 	}
 	# Guard Break
 	if GuardBreak {
-		if Map(_iksys_actionGuardBreak) = 0 {
+		if Map(_iksys_actionGuardBreak) = 0 && TeamSide = 1 {
+			LifebarAction{spr: Const(MsgGuardBreak), 0; timemul: 2}
+			MapSet{map: "_iksys_actionGuardBreak"; value: 1}
+		} else if Map(_iksys_actionGuardBreak) = 0 && TeamSide = 2 {
 			LifebarAction{spr: Const(MsgGuardBreak), 0; timemul: 2}
 			MapSet{map: "_iksys_actionGuardBreak"; value: 1}
 		}
@@ -72,7 +98,10 @@ if !Const(Default.Enable.Action) || TeamSide = 0 {
 		MapSet{map: "_iksys_actionGuardBreak"; value: 0}
 	}
 	# Partner Down
-	if NumPartner > 0 && !Alive && Map(_iksys_actionDownFlag) = 0 {
+	if NumPartner > 0 && !Alive && Map(_iksys_actionDownFlag) = 0 && TeamSide = 1 {
+		LifebarAction{spr: Const(MsgPartnerDown), 0; timemul: 2}
+		MapSet{map: "_iksys_actionDownFlag"; value: 1}
+	} else if NumPartner > 0 && !Alive && Map(_iksys_actionDownFlag) = 0 && TeamSide = 2 {
 		LifebarAction{spr: Const(MsgPartnerDown), 0; timemul: 2}
 		MapSet{map: "_iksys_actionDownFlag"; value: 1}
 	}
@@ -81,31 +110,58 @@ if !Const(Default.Enable.Action) || TeamSide = 0 {
 		# Combo
 		if ComboCount != Map(_iksys_actionComboCount) {
 			if ComboCount < Map(_iksys_actionComboCount) {
-				if Map(_iksys_actionComboCount) >= 25 {
-					LifebarAction{spr: Const(MsgCombo25), 0} #gdlk combo (mugen)
-				} else if Map(_iksys_actionComboCount) >= 20 {
-					LifebarAction{spr: Const(MsgCombo20), 0} #amazing combo (marvelous)
-				} else if Map(_iksys_actionComboCount) >= 15 {
-					LifebarAction{spr: Const(MsgCombo15), 0} #great combo (fantastic)
-				} else if Map(_iksys_actionComboCount) >= 10 {
-					LifebarAction{spr: Const(MsgCombo10), 0} #sweet combo (beautiful)
-				} else if Map(_iksys_actionComboCount) >= 5 {
-					LifebarAction{spr: Const(MsgCombo5), 0} #good combo (great)
-				} else if Map(_iksys_actionComboCount) >= 3 {
-					LifebarAction{spr: Const(MsgCombo3), 0} #nice combo (good)
+				if TeamSide = 1 { 
+					if Map(_iksys_actionComboCount) >= 25 {
+						LifebarAction{spr: Const(MsgCombo25), 0} #gdlk combo (mugen)
+					} else if Map(_iksys_actionComboCount) >= 20 {
+						LifebarAction{spr: Const(MsgCombo20), 0} #amazing combo (marvelous)
+					} else if Map(_iksys_actionComboCount) >= 15 {
+						LifebarAction{spr: Const(MsgCombo15), 0} #great combo (fantastic)
+					} else if Map(_iksys_actionComboCount) >= 10 {
+						LifebarAction{spr: Const(MsgCombo10), 0} #sweet combo (beautiful)
+					} else if Map(_iksys_actionComboCount) >= 5 {
+						LifebarAction{spr: Const(MsgCombo5), 0} #good combo (great)
+					} else if Map(_iksys_actionComboCount) >= 3 {
+						LifebarAction{spr: Const(MsgCombo3), 0} #nice combo (good)
+					}
+				} else if TeamSide = 2 {
+					if Map(_iksys_actionComboCount) >= 25 {
+						LifebarAction{spr: Const(MsgCombo25), 0} #gdlk combo (mugen)
+					} else if Map(_iksys_actionComboCount) >= 20 {
+						LifebarAction{spr: Const(MsgCombo20), 0} #amazing combo (marvelous)
+					} else if Map(_iksys_actionComboCount) >= 15 {
+						LifebarAction{spr: Const(MsgCombo15), 0} #great combo (fantastic)
+					} else if Map(_iksys_actionComboCount) >= 10 {
+						LifebarAction{spr: Const(MsgCombo10), 0} #sweet combo (beautiful)
+					} else if Map(_iksys_actionComboCount) >= 5 {
+						LifebarAction{spr: Const(MsgCombo5), 0} #good combo (great)
+					} else if Map(_iksys_actionComboCount) >= 3 {
+						LifebarAction{spr: Const(MsgCombo3), 0} #nice combo (good)
+					}
 				}
 			}
 			MapSet{map: "_iksys_actionComboCount"; value: ComboCount}
 		}
 		# Win
 		if Win && Map(_iksys_actionWinFlag) = 0 {
-			if WinPerfect {
-				LifebarAction{spr: Const(MsgWinPerfect), 0; timemul: 3}
-			}
-			if WinHyper {
-				LifebarAction{spr: Const(MsgWinHyper), 0; timemul: 3}
-			} else if WinSpecial {
-				LifebarAction{spr: Const(MsgWinSpecial), 0; timemul: 3}
+			if TeamSide = 1 {
+				if WinPerfect {
+					LifebarAction{spr: Const(MsgWinPerfect), 0; timemul: 3}
+				}
+				if WinHyper {
+					LifebarAction{spr: Const(MsgWinHyper), 0; timemul: 3}
+				} else if WinSpecial {
+					LifebarAction{spr: Const(MsgWinSpecial), 0; timemul: 3}
+				}
+			} else if TeamSide = 2 {
+				if WinPerfect {
+					LifebarAction{spr: Const(MsgWinPerfect), 0; timemul: 3}
+				}
+				if WinHyper {
+					LifebarAction{spr: Const(MsgWinHyper), 0; timemul: 3}
+				} else if WinSpecial {
+					LifebarAction{spr: Const(MsgWinSpecial), 0; timemul: 3}
+				}
 			}
 			MapSet{map: "_iksys_actionWinFlag"; value: 1}
 		}

--- a/data/action.zss
+++ b/data/action.zss
@@ -10,7 +10,7 @@ if !Const(Default.Enable.Action) || TeamSide = 0 {
 	ignorehitpause if HelperName = "Parry Detection" && MoveHit = 1 {
 		if TeamSide = 1 {
 			LifebarAction{spr: Const(MsgParry), 0}
-		else if TeamSide = 2 {
+		} else if TeamSide = 2 {
 			LifebarAction{spr: Const(MsgParry), 0}
 		}
 	}

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2014,7 +2014,10 @@ function start.f_selectScreen()
 				if stageListNo == 0 then
 					t_txt[1] = motif.select_info.stage_random_text
 				else
-					t_txt = main.f_extractText(motif.select_info.stage_text, stageListNo, main.t_selStages[main.t_selectableStages[stageListNo]].name)
+					for i = 1, #main.t_selectableStages do
+						t_txt[i] = motif.select_info.stage_text:gsub('%%i', tostring(stageListNo))
+						t_txt[i] = t_txt[i]:gsub('%%s', main.t_selStages[main.t_selectableStages[stageListNo]].name)
+					end
 				end
 				for i = 1, #t_txt do
 					txt_selStage:update({

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2014,9 +2014,11 @@ function start.f_selectScreen()
 				if stageListNo == 0 then
 					t_txt[1] = motif.select_info.stage_random_text
 				else
-					for i = 1, #main.t_selectableStages do
-						t_txt[i] = motif.select_info.stage_text:gsub('%%i', tostring(stageListNo))
-						t_txt[i] = t_txt[i]:gsub('%%s', main.t_selStages[main.t_selectableStages[stageListNo]].name)
+					t = motif.select_info.stage_text:gsub('%%i', tostring(stageListNo))
+					t = t:gsub('\n', '\\n')
+					t = t:gsub('%%s', main.t_selStages[main.t_selectableStages[stageListNo]].name)
+					for i, c in ipairs(main.f_strsplit('\\n', t)) do --split string using "\n" delimiter
+						t_txt[i] = c
 					end
 				end
 				for i = 1, #t_txt do

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -575,7 +575,7 @@ func (gb *GuardBar) step(ref int, gbr *GuardBar, snd *Snd) {
 	if !sys.lifebar.activeGb {
 		return
 	}
-	power := float32(sys.chars[ref][0].power) / float32(sys.chars[ref][0].powerMax)
+	power := float32(sys.chars[ref][0].guardPoints) / float32(sys.chars[ref][0].guardPointsMax)
 	gb.shift.anim.srcAlpha = int16(255 * (1 - power))
 	gb.shift.anim.dstAlpha = int16(255 * power)
 	gbr.midpower -= 1.0 / 144
@@ -716,7 +716,7 @@ func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
 	if !sys.lifebar.activeSb {
 		return
 	}
-	power := 1 - float32(sys.chars[ref][0].power)/float32(sys.chars[ref][0].powerMax)
+	power := 1 - float32(sys.chars[ref][0].dizzyPoints)/float32(sys.chars[ref][0].dizzyPointsMax)
 	sb.shift.anim.srcAlpha = int16(255 * power)
 	sb.shift.anim.dstAlpha = int16(255 * (1 - power))
 	sbr.midpower -= 1.0 / 144
@@ -735,7 +735,7 @@ func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
 	sb.mid.Action()
 	var mv float32
 	for k := range sb.front {
-		if k > mv && power >= k/100 {
+		if k > mv && (1-power) >= k/100 {
 			mv = k
 		}
 	}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -530,6 +530,8 @@ type GuardBar struct {
 	bg2         AnimLayout
 	top         AnimLayout
 	mid         AnimLayout
+	warn        AnimLayout
+	warn_val    int32
 	value       LbText
 	front       map[float32]*AnimLayout
 	shift       AnimLayout
@@ -569,6 +571,8 @@ func readGuardBar(pre string, is IniSection,
 	}
 	gb.shift = *ReadAnimLayout(pre+"shift.", is, sff, at, 0)
 	gb.value = *readLbText(pre+"value.", is, "%d", 0, f, 0)
+	is.ReadI32(pre+"warn.val", &gb.warn_val)
+	gb.warn = *ReadAnimLayout(pre+"warn.", is, sff, at, 0)
 	return gb
 }
 func (gb *GuardBar) step(ref int, gbr *GuardBar, snd *Snd) {
@@ -600,6 +604,7 @@ func (gb *GuardBar) step(ref int, gbr *GuardBar, snd *Snd) {
 	}
 	gb.front[mv].Action()
 	gb.shift.Action()
+	gb.warn.Action()
 }
 func (gb *GuardBar) reset() {
 	gb.bg0.Reset()
@@ -613,6 +618,7 @@ func (gb *GuardBar) reset() {
 	gb.shift.Reset()
 	gb.shift.anim.srcAlpha = 0
 	gb.shift.anim.dstAlpha = 255
+	gb.warn.Reset()
 }
 func (gb *GuardBar) bgDraw(layerno int16) {
 	if !sys.lifebar.activeGb {
@@ -662,6 +668,9 @@ func (gb *GuardBar) draw(layerno int16, ref int, gbr *GuardBar, f []*Fnt) {
 		gb.value.lay.DrawText(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), sys.lifebarScale,
 			layerno, text, f[gb.value.font[0]], gb.value.font[1], gb.value.font[2], gb.value.palfx, gb.value.frgba)
 	}
+	if power < float32(gb.warn_val)/100 {
+		gb.warn.DrawScaled(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), layerno, sys.lifebarScale)
+	}
 	gb.top.DrawScaled(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), layerno, sys.lifebarScale)
 }
 
@@ -673,6 +682,8 @@ type StunBar struct {
 	bg2         AnimLayout
 	top         AnimLayout
 	mid         AnimLayout
+	warn_val    int32
+	warn        AnimLayout
 	value       LbText
 	front       map[float32]*AnimLayout
 	shift       AnimLayout
@@ -710,6 +721,8 @@ func readStunBar(pre string, is IniSection,
 	}
 	sb.shift = *ReadAnimLayout(pre+"shift.", is, sff, at, 0)
 	sb.value = *readLbText(pre+"value.", is, "%d", 0, f, 0)
+	is.ReadI32(pre+"warn.val", &sb.warn_val)
+	sb.warn = *ReadAnimLayout(pre+"warn.", is, sff, at, 0)
 	return sb
 }
 func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
@@ -741,6 +754,7 @@ func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
 	}
 	sb.front[mv].Action()
 	sb.shift.Action()
+	sb.warn.Action()
 }
 func (sb *StunBar) reset() {
 	sb.bg0.Reset()
@@ -754,6 +768,7 @@ func (sb *StunBar) reset() {
 	sb.shift.Reset()
 	sb.shift.anim.srcAlpha = 255
 	sb.shift.anim.dstAlpha = 0
+	sb.warn.Reset()
 }
 func (sb *StunBar) bgDraw(layerno int16) {
 	if !sys.lifebar.activeSb {
@@ -802,6 +817,9 @@ func (sb *StunBar) draw(layerno int16, ref int, sbr *StunBar, f []*Fnt) {
 		text = strings.Replace(text, "%p", fmt.Sprintf("%v", math.Round(float64(power)*100)), 1)
 		sb.value.lay.DrawText(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), sys.lifebarScale,
 			layerno, text, f[sb.value.font[0]], sb.value.font[1], sb.value.font[2], sb.value.palfx, sb.value.frgba)
+	}
+	if power > float32(sb.warn_val)/100 {
+		sb.warn.DrawScaled(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), layerno, sys.lifebarScale)
 	}
 	sb.top.DrawScaled(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), layerno, sys.lifebarScale)
 }

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -735,7 +735,7 @@ func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
 	sb.mid.Action()
 	var mv float32
 	for k := range sb.front {
-		if k > mv && (1-power) >= k/100 {
+		if k > mv && power >= k/100 {
 			mv = k
 		}
 	}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1533,23 +1533,23 @@ type LifeBarRound struct {
 	round_default      AnimTextSnd
 	round              [9]AnimTextSnd
 	round_default_top  AnimTextSnd
-	round_default_bg   [16]AnimLayout
+	round_default_bg   [32]AnimLayout
 	round_final        AnimTextSnd
 	fight_time         int32
 	fight_sndtime      int32
 	fight              AnimTextSnd
 	fight_top          AnimTextSnd
-	fight_bg           [16]AnimLayout
+	fight_bg           [32]AnimLayout
 	ctrl_time          int32
 	ko_time            int32
 	ko_sndtime         int32
 	ko, dko, to        AnimTextSnd
 	ko_top             AnimTextSnd
-	ko_bg              [16]AnimLayout
+	ko_bg              [32]AnimLayout
 	dko_top            AnimTextSnd
-	dko_bg             [16]AnimLayout
+	dko_bg             [32]AnimLayout
 	to_top             AnimTextSnd
-	to_bg              [16]AnimLayout
+	to_bg              [32]AnimLayout
 	slow_time          int32
 	slow_fadetime      int32
 	slow_speed         float32

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1533,7 +1533,7 @@ type LifeBarRound struct {
 	round_default      AnimTextSnd
 	round              [9]AnimTextSnd
 	round_default_top  AnimTextSnd
-	round_default_bg   [9]AnimLayout
+	round_default_bg   [16]AnimLayout
 	round_final        AnimTextSnd
 	fight_time         int32
 	fight_sndtime      int32

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1532,23 +1532,25 @@ type LifeBarRound struct {
 	round_sndtime      int32
 	round_default      AnimTextSnd
 	round              [9]AnimTextSnd
-	round_default_top  AnimTextSnd
+	round_default_top  AnimLayout
 	round_default_bg   [32]AnimLayout
 	round_final        AnimTextSnd
+	round_final_top    AnimLayout
+	round_final_bg     [32]AnimLayout
 	fight_time         int32
 	fight_sndtime      int32
 	fight              AnimTextSnd
-	fight_top          AnimTextSnd
+	fight_top          AnimLayout
 	fight_bg           [32]AnimLayout
 	ctrl_time          int32
 	ko_time            int32
 	ko_sndtime         int32
 	ko, dko, to        AnimTextSnd
-	ko_top             AnimTextSnd
+	ko_top             AnimLayout
 	ko_bg              [32]AnimLayout
-	dko_top            AnimTextSnd
+	dko_top            AnimLayout
 	dko_bg             [32]AnimLayout
-	to_top             AnimTextSnd
+	to_top             AnimLayout
 	to_bg              [32]AnimLayout
 	slow_time          int32
 	slow_fadetime      int32
@@ -1560,7 +1562,17 @@ type LifeBarRound struct {
 	win_time           int32
 	win_sndtime        int32
 	win, win2, drawn   AnimTextSnd
+	win_top            AnimLayout
+	win_bg             [32]AnimLayout
+	win2_top           AnimLayout
+	win2_bg            [32]AnimLayout
+	drawn_top          AnimLayout
+	drawn_bg           [32]AnimLayout
 	win3, win4         AnimTextSnd
+	win3_top           AnimLayout
+	win3_bg            [32]AnimLayout
+	win4_top           AnimLayout
+	win4_bg            [32]AnimLayout
 	cur                int32
 	wt, swt, dt        [4]int32
 	timerActive        bool
@@ -1597,7 +1609,7 @@ func readLifeBarRound(is IniSection,
 	}
 	is.ReadI32("round.time", &ro.round_time)
 	is.ReadI32("round.sndtime", &ro.round_sndtime)
-	ro.round_default_top = *ReadAnimTextSnd("round.default.top.", is, sff, at, 2, f)
+	ro.round_default_top = *ReadAnimLayout("round.default.top.", is, sff, at, 2)
 	for i := range ro.round_default_bg {
 		ro.round_default_bg[i] = *ReadAnimLayout(fmt.Sprintf("round.default.bg%v.", i), is, sff, at, 2)
 	}
@@ -1605,11 +1617,15 @@ func readLifeBarRound(is IniSection,
 	for i := range ro.round {
 		ro.round[i] = *ReadAnimTextSnd(fmt.Sprintf("round%v.", i+1), is, sff, at, 2, f)
 	}
+	for i := range ro.round_final_bg {
+		ro.round_final_bg[i] = *ReadAnimLayout(fmt.Sprintf("round.final.bg%v.", i), is, sff, at, 2)
+	}
+	ro.round_final_top = *ReadAnimLayout("round.final.top.", is, sff, at, 2)
 	ro.round_final = *ReadAnimTextSnd("round.final.", is, sff, at, 2, f)
 	is.ReadI32("fight.time", &ro.fight_time)
 	is.ReadI32("fight.sndtime", &ro.fight_sndtime)
 	ro.fight = *ReadAnimTextSnd("fight.", is, sff, at, 2, f)
-	ro.fight_top = *ReadAnimTextSnd("fight.top.", is, sff, at, 2, f)
+	ro.fight_top = *ReadAnimLayout("fight.top.", is, sff, at, 2)
 	for i := range ro.fight_bg {
 		ro.fight_bg[i] = *ReadAnimLayout(fmt.Sprintf("fight.bg%v.", i), is, sff, at, 2)
 	}
@@ -1619,17 +1635,17 @@ func readLifeBarRound(is IniSection,
 	is.ReadI32("ko.time", &ro.ko_time)
 	is.ReadI32("ko.sndtime", &ro.ko_sndtime)
 	ro.ko = *ReadAnimTextSnd("ko.", is, sff, at, 1, f)
-	ro.ko_top = *ReadAnimTextSnd("ko.top.", is, sff, at, 1, f)
+	ro.ko_top = *ReadAnimLayout("ko.top.", is, sff, at, 1)
 	for i := range ro.ko_bg {
 		ro.ko_bg[i] = *ReadAnimLayout(fmt.Sprintf("ko.bg%v.", i), is, sff, at, 2)
 	}
 	ro.dko = *ReadAnimTextSnd("dko.", is, sff, at, 1, f)
-	ro.dko_top = *ReadAnimTextSnd("dko.top.", is, sff, at, 1, f)
+	ro.dko_top = *ReadAnimLayout("dko.top.", is, sff, at, 1)
 	for i := range ro.dko_bg {
 		ro.dko_bg[i] = *ReadAnimLayout(fmt.Sprintf("dko.bg%v.", i), is, sff, at, 2)
 	}
 	ro.to = *ReadAnimTextSnd("to.", is, sff, at, 1, f)
-	ro.to_top = *ReadAnimTextSnd("to.top.", is, sff, at, 1, f)
+	ro.to_top = *ReadAnimLayout("to.top.", is, sff, at, 1)
 	for i := range ro.to_bg {
 		ro.to_bg[i] = *ReadAnimLayout(fmt.Sprintf("to.bg%v.", i), is, sff, at, 2)
 	}
@@ -1657,18 +1673,46 @@ func readLifeBarRound(is IniSection,
 	is.ReadI32("win.time", &ro.win_time)
 	is.ReadI32("win.sndtime", &ro.win_sndtime)
 	ro.win = *ReadAnimTextSnd("win.", is, sff, at, 1, f)
+	ro.win_top = *ReadAnimLayout("win.top.", is, sff, at, 1)
+	for i := range ro.win_bg {
+		ro.win_bg[i] = *ReadAnimLayout(fmt.Sprintf("win.bg%v.", i), is, sff, at, 1)
+	}
 	ro.win2 = *ReadAnimTextSnd("win2.", is, sff, at, 1, f)
+	ro.win2_top = *ReadAnimLayout("win2.top.", is, sff, at, 1)
+	for i := range ro.win2_bg {
+		ro.win2_bg[i] = *ReadAnimLayout(fmt.Sprintf("win2.bg%v.", i), is, sff, at, 1)
+	}
 	if _, ok := is["win3.text"]; ok {
 		ro.win3 = *ReadAnimTextSnd("win3.", is, sff, at, 1, f)
+		ro.win3_top = *ReadAnimLayout("win3.top.", is, sff, at, 1)
+		for i := range ro.win3_bg {
+			ro.win3_bg[i] = *ReadAnimLayout(fmt.Sprintf("win3.bg%v.", i), is, sff, at, 1)
+		}
 	} else {
 		ro.win3 = ro.win2
+		ro.win3_top = *ReadAnimLayout("win2.top.", is, sff, at, 1)
+		for i := range ro.win2_bg {
+			ro.win3_bg[i] = *ReadAnimLayout(fmt.Sprintf("win2.bg%v.", i), is, sff, at, 1)
+		}
 	}
 	if _, ok := is["win4.text"]; ok {
 		ro.win4 = *ReadAnimTextSnd("win4.", is, sff, at, 1, f)
+		ro.win4_top = *ReadAnimLayout("win4.top.", is, sff, at, 1)
+		for i := range ro.win4_bg {
+			ro.win4_bg[i] = *ReadAnimLayout(fmt.Sprintf("win4.bg%v.", i), is, sff, at, 1)
+		}
 	} else {
 		ro.win4 = ro.win2
+		ro.win4_top = *ReadAnimLayout("win2.top.", is, sff, at, 1)
+		for i := range ro.win2_bg {
+			ro.win4_bg[i] = *ReadAnimLayout(fmt.Sprintf("win2.bg%v.", i), is, sff, at, 1)
+		}
 	}
 	ro.drawn = *ReadAnimTextSnd("draw.", is, sff, at, 1, f)
+	ro.drawn_top = *ReadAnimLayout("draw.top.", is, sff, at, 1)
+	for i := range ro.drawn_bg {
+		ro.drawn_bg[i] = *ReadAnimLayout(fmt.Sprintf("draw.bg%v.", i), is, sff, at, 1)
+	}
 	ro.wint[WT_N] = readLbBgTextSnd("p1.n.", is, sff, at, 0, f)
 	ro.wint[WT_S] = readLbBgTextSnd("p1.s.", is, sff, at, 0, f)
 	ro.wint[WT_H] = readLbBgTextSnd("p1.h.", is, sff, at, 0, f)
@@ -1748,14 +1792,27 @@ func (ro *LifeBarRound) act() bool {
 				ro.swt[0]--
 				if ro.wt[0] <= 0 {
 					ro.dt[0]++
-					if sys.roundType[0] == RT_Final && ro.round_final.snd[0] != -1 {
-						ro.round_default_top.Action()
-						ro.round_final.Action()
-						ro.round_default.Action()
-						for i := len(ro.round_default_bg) - 1; i >= 0; i-- {
-							ro.round_default_bg[i].Action()
+					if sys.roundType[0] == RT_Final {
+						if len(ro.round_final_top.anim.frames) > 0 {
+							ro.round_final_top.Action()
+						} else {
+							ro.round_default_top.Action()
 						}
-						ro.introState[0] = ro.round_final.End(ro.dt[0], true) && ro.round_default.End(ro.dt[0], true) && ro.round_default_top.End(ro.dt[0], true)
+						if len(ro.round_final.anim.anim.frames) > 0 {
+							ro.round_final.Action()
+						} else {
+							ro.round_default.Action()
+						}
+						if len(ro.round_final_bg[0].anim.frames) > 0 {
+							for i := len(ro.round_final_bg) - 1; i >= 0; i-- {
+								ro.round_final_bg[i].Action()
+							}
+						} else {
+							for i := len(ro.round_default_bg) - 1; i >= 0; i-- {
+								ro.round_default_bg[i].Action()
+							}
+						}
+						ro.introState[0] = ro.round_final.End(ro.dt[0], true) && ro.round_default.End(ro.dt[0], true)
 					} else if int(sys.round) <= len(ro.round) {
 						ro.round_default_top.Action()
 						ro.round[sys.round-1].Action()
@@ -1763,14 +1820,14 @@ func (ro *LifeBarRound) act() bool {
 						for i := len(ro.round_default_bg) - 1; i >= 0; i-- {
 							ro.round_default_bg[i].Action()
 						}
-						ro.introState[0] = ro.round[sys.round-1].End(ro.dt[0], true) && ro.round_default.End(ro.dt[0], true) && ro.round_default_top.End(ro.dt[0], true)
+						ro.introState[0] = ro.round[sys.round-1].End(ro.dt[0], true) && ro.round_default.End(ro.dt[0], true)
 					} else {
 						ro.round_default_top.Action()
 						ro.round_default.Action()
 						for i := len(ro.round_default_bg) - 1; i >= 0; i-- {
 							ro.round_default_bg[i].Action()
 						}
-						ro.introState[0] = ro.round_default.End(ro.dt[0], true) && ro.round_default_top.End(ro.dt[0], true)
+						ro.introState[0] = ro.round_default.End(ro.dt[0], true)
 					}
 				}
 				ro.wt[0]--
@@ -1850,17 +1907,37 @@ func (ro *LifeBarRound) act() bool {
 			}
 			if sys.intro < -(ro.over_hittime + ro.over_waittime + ro.over_wintime) {
 				if /*sys.finish == FT_DKO ||*/ sys.finish == FT_TODraw {
+					ro.drawn_top.Action()
 					f(&ro.drawn, 3)
+					for i := len(ro.drawn_bg) - 1; i >= 0; i-- {
+						ro.drawn_bg[i].Action()
+					}
 				} else if sys.winTeam >= 0 && (sys.tmode[sys.winTeam] == TM_Simul || sys.tmode[sys.winTeam] == TM_Tag) {
 					if sys.numSimul[sys.winTeam] == 2 {
+						ro.win2_top.Action()
 						f(&ro.win2, 3)
+						for i := len(ro.win2_bg) - 1; i >= 0; i-- {
+							ro.win2_bg[i].Action()
+						}
 					} else if sys.numSimul[sys.winTeam] == 3 {
+						ro.win3_top.Action()
 						f(&ro.win3, 3)
+						for i := len(ro.win3_bg) - 1; i >= 0; i-- {
+							ro.win3_bg[i].Action()
+						}
 					} else {
+						ro.win4_top.Action()
 						f(&ro.win4, 3)
+						for i := len(ro.win4_bg) - 1; i >= 0; i-- {
+							ro.win4_bg[i].Action()
+						}
 					}
 				} else {
+					ro.win_top.Action()
 					f(&ro.win, 3)
+					for i := len(ro.win_bg) - 1; i >= 0; i-- {
+						ro.win_bg[i].Action()
+					}
 				}
 			}
 		} else {
@@ -1904,6 +1981,10 @@ func (ro *LifeBarRound) reset() {
 	for i := range ro.round {
 		ro.round[i].Reset()
 	}
+	ro.round_final_top.Reset()
+	for i := range ro.round_final_bg {
+		ro.round_final_bg[i].Reset()
+	}
 	ro.round_final.Reset()
 	ro.fight.Reset()
 	ro.fight_top.Reset()
@@ -1926,10 +2007,30 @@ func (ro *LifeBarRound) reset() {
 		ro.to_bg[i].Reset()
 	}
 	ro.win.Reset()
+	ro.win_top.Reset()
+	for i := range ro.win_bg {
+		ro.win_bg[i].Reset()
+	}
 	ro.win2.Reset()
+	ro.win2_top.Reset()
+	for i := range ro.win2_bg {
+		ro.win2_bg[i].Reset()
+	}
 	ro.win3.Reset()
+	ro.win3_top.Reset()
+	for i := range ro.win3_bg {
+		ro.win3_bg[i].Reset()
+	}
 	ro.win4.Reset()
+	ro.win4_top.Reset()
+	for i := range ro.win4_bg {
+		ro.win4_bg[i].Reset()
+	}
 	ro.drawn.Reset()
+	ro.drawn_top.Reset()
+	for i := range ro.drawn_bg {
+		ro.drawn_bg[i].Reset()
+	}
 	for i := range ro.wint {
 		ro.wint[i].reset()
 	}
@@ -1949,9 +2050,12 @@ func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
 			layerno, f, sys.lifebarScale)
 		ro.round_default.text.text = tmp
 		if sys.roundType[0] == RT_Final && (ro.round_final.text.font[0] != -1 ||
-			len(ro.round_final.anim.anim.frames) > 0) {
+			len(ro.round_final.anim.anim.frames) > 0 || len(ro.round_final_bg[0].anim.frames) > 0) {
 			tmp = ro.round_final.text.text
 			ro.round_final.text.text = OldSprintf(tmp, sys.round)
+			for i := range ro.round_final_bg {
+				ro.round_final_bg[i].DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+			}
 			ro.round_final.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]),
 				layerno, f, sys.lifebarScale)
 			ro.round_final.text.text = tmp
@@ -1962,15 +2066,18 @@ func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
 				layerno, f, sys.lifebarScale)
 			ro.round[sys.round-1].text.text = tmp
 		}
-		ro.round_default_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]),
-			layerno, f, sys.lifebarScale)
+		if sys.roundType[0] == RT_Final && len(ro.round_final_top.anim.frames) > 0 {
+			ro.round_final_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+		} else {
+			ro.round_default_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+		}
 	}
 	if !ro.introState[1] && ro.wt[1] < 0 {
 		for i := range ro.fight_bg { //240z
 			ro.fight_bg[i].DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale) //240z
 		}
 		ro.fight.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
-		ro.fight_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
+		ro.fight_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 	}
 	if ro.cur == 2 {
 		if /*ro.wt[2] < 0 && sys.intro < -ro.ko_time-10*/ ro.wt[2] < -ro.ko_time-10 {
@@ -1980,24 +2087,28 @@ func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
 					ro.ko_bg[i].DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 				}
 				ro.ko.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
-				ro.ko_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
+				ro.ko_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 			case FT_DKO:
 				for i := range ro.dko_bg {
 					ro.dko_bg[i].DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 				}
 				ro.dko.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
-				ro.dko_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
+				ro.dko_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 			default:
 				for i := range ro.to_bg {
 					ro.to_bg[i].DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 				}
 				ro.to.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
-				ro.to_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
+				ro.to_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 			}
 		}
 		if ro.wt[3] < 0 {
 			if /*sys.finish == FT_DKO ||*/ sys.finish == FT_TODraw {
+				for i := range ro.drawn_bg {
+					ro.drawn_bg[i].DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+				}
 				ro.drawn.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
+				ro.drawn_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 			} else if sys.winTeam >= 0 && (sys.tmode[sys.winTeam] == TM_Simul || sys.tmode[sys.winTeam] == TM_Tag) {
 				var inter []interface{}
 				for i := sys.winTeam; i < len(sys.chars); i += 2 {
@@ -2007,25 +2118,41 @@ func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
 				}
 				if sys.numSimul[sys.winTeam] == 2 {
 					tmp := ro.win2.text.text
+					for i := range ro.win2_bg {
+						ro.win2_bg[i].DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+					}
 					ro.win2.text.text = OldSprintf(tmp, inter...)
 					ro.win2.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
 					ro.win2.text.text = tmp
+					ro.win2_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 				} else if sys.numSimul[sys.winTeam] == 3 {
 					tmp := ro.win3.text.text
+					for i := range ro.win3_bg {
+						ro.win3_bg[i].DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+					}
 					ro.win3.text.text = OldSprintf(tmp, inter...)
 					ro.win3.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
 					ro.win3.text.text = tmp
+					ro.win3_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 				} else {
 					tmp := ro.win4.text.text
+					for i := range ro.win4_bg {
+						ro.win4_bg[i].DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+					}
 					ro.win4.text.text = OldSprintf(tmp, inter...)
 					ro.win4.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
 					ro.win4.text.text = tmp
+					ro.win4_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 				}
 			} else if sys.winTeam >= 0 {
 				tmp := ro.win.text.text
+				for i := range ro.win_bg {
+					ro.win_bg[i].DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+				}
 				ro.win.text.text = OldSprintf(tmp, sys.cgi[sys.winTeam].displayname)
 				ro.win.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, f, sys.lifebarScale)
 				ro.win.text.text = tmp
+				ro.win_top.DrawScaled(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
 			}
 		}
 	}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1798,11 +1798,11 @@ func (ro *LifeBarRound) act() bool {
 						} else {
 							ro.round_default_top.Action()
 						}
-						if len(ro.round_final.anim.anim.frames) > 0 {
-							ro.round_final.Action()
-						} else {
-							ro.round_default.Action()
-						}
+						//if len(ro.round_final.anim.anim.frames) > 0 {
+						ro.round_final.Action()
+						//} else {
+						ro.round_default.Action()
+						//}
 						if len(ro.round_final_bg[0].anim.frames) > 0 {
 							for i := len(ro.round_final_bg) - 1; i >= 0; i-- {
 								ro.round_final_bg[i].Action()

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -148,6 +148,8 @@ type HealthBar struct {
 	red        map[int32]*AnimLayout
 	front      map[float32]*AnimLayout
 	shift      AnimLayout
+	warn       AnimLayout
+	warn_range [2]int32
 	value      LbText
 	oldlife    float32
 	midlife    float32
@@ -212,6 +214,8 @@ func readHealthBar(pre string, is IniSection,
 	is.ReadF32("mid.mult", &hb.mid_mult)
 	is.ReadF32("mid.steps", &hb.mid_steps)
 	hb.mid_steps = MaxF(1, hb.mid_steps)
+	is.ReadI32(pre+"warn.range", &hb.warn_range[0], &hb.warn_range[1])
+	hb.warn = *ReadAnimLayout(pre+"warn.", is, sff, at, 0)
 	return hb
 }
 func (hb *HealthBar) step(ref int, hbr *HealthBar) {
@@ -274,6 +278,7 @@ func (hb *HealthBar) step(ref int, hbr *HealthBar) {
 	}
 	hb.front[fv].Action()
 	hb.shift.Action()
+	hb.warn.Action()
 }
 func (hb *HealthBar) reset() {
 	hb.bg0.Reset()
@@ -290,6 +295,7 @@ func (hb *HealthBar) reset() {
 	for _, v := range hb.red {
 		v.Reset()
 	}
+	hb.warn.Reset()
 }
 func (hb *HealthBar) bgDraw(layerno int16) {
 	hb.bg0.DrawScaled(float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), layerno, sys.lifebarScale)
@@ -355,6 +361,9 @@ func (hb *HealthBar) draw(layerno int16, ref int, hbr *HealthBar, f []*Fnt) {
 			layerno, text, f[hb.value.font[0]], hb.value.font[1], hb.value.font[2], hb.value.palfx, hb.value.frgba)
 	}
 	hb.top.DrawScaled(float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), layerno, sys.lifebarScale)
+	if life < float32(hb.warn_range[0])/100 && life > float32(hb.warn_range[1])/100 {
+		hb.warn.DrawScaled(float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), layerno, sys.lifebarScale)
+	}
 }
 
 type PowerBar struct {
@@ -537,7 +546,6 @@ type GuardBar struct {
 	shift       AnimLayout
 	midpower    float32
 	midpowerMin float32
-	// TODO: Add a effect similar to the one were life is removed.
 	//prevLevel   int32
 }
 

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1539,17 +1539,17 @@ type LifeBarRound struct {
 	fight_sndtime      int32
 	fight              AnimTextSnd
 	fight_top          AnimTextSnd
-	fight_bg           [9]AnimLayout
+	fight_bg           [16]AnimLayout
 	ctrl_time          int32
 	ko_time            int32
 	ko_sndtime         int32
 	ko, dko, to        AnimTextSnd
 	ko_top             AnimTextSnd
-	ko_bg              [9]AnimLayout
+	ko_bg              [16]AnimLayout
 	dko_top            AnimTextSnd
-	dko_bg             [9]AnimLayout
+	dko_bg             [16]AnimLayout
 	to_top             AnimTextSnd
-	to_bg              [9]AnimLayout
+	to_bg              [16]AnimLayout
 	slow_time          int32
 	slow_fadetime      int32
 	slow_speed         float32

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -531,7 +531,7 @@ type GuardBar struct {
 	top         AnimLayout
 	mid         AnimLayout
 	warn        AnimLayout
-	warn_val    int32
+	warn_range  [2]int32
 	value       LbText
 	front       map[float32]*AnimLayout
 	shift       AnimLayout
@@ -571,7 +571,7 @@ func readGuardBar(pre string, is IniSection,
 	}
 	gb.shift = *ReadAnimLayout(pre+"shift.", is, sff, at, 0)
 	gb.value = *readLbText(pre+"value.", is, "%d", 0, f, 0)
-	is.ReadI32(pre+"warn.val", &gb.warn_val)
+	is.ReadI32(pre+"warn.range", &gb.warn_range[0], &gb.warn_range[1])
 	gb.warn = *ReadAnimLayout(pre+"warn.", is, sff, at, 0)
 	return gb
 }
@@ -668,7 +668,7 @@ func (gb *GuardBar) draw(layerno int16, ref int, gbr *GuardBar, f []*Fnt) {
 		gb.value.lay.DrawText(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), sys.lifebarScale,
 			layerno, text, f[gb.value.font[0]], gb.value.font[1], gb.value.font[2], gb.value.palfx, gb.value.frgba)
 	}
-	if power < float32(gb.warn_val)/100 {
+	if power < float32(gb.warn_range[0])/100 && power > float32(gb.warn_range[1])/100 {
 		gb.warn.DrawScaled(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), layerno, sys.lifebarScale)
 	}
 	gb.top.DrawScaled(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), layerno, sys.lifebarScale)
@@ -682,7 +682,7 @@ type StunBar struct {
 	bg2         AnimLayout
 	top         AnimLayout
 	mid         AnimLayout
-	warn_val    int32
+	warn_range  [2]int32
 	warn        AnimLayout
 	value       LbText
 	front       map[float32]*AnimLayout
@@ -721,7 +721,7 @@ func readStunBar(pre string, is IniSection,
 	}
 	sb.shift = *ReadAnimLayout(pre+"shift.", is, sff, at, 0)
 	sb.value = *readLbText(pre+"value.", is, "%d", 0, f, 0)
-	is.ReadI32(pre+"warn.val", &sb.warn_val)
+	is.ReadI32(pre+"warn.range", &sb.warn_range[0], &sb.warn_range[1])
 	sb.warn = *ReadAnimLayout(pre+"warn.", is, sff, at, 0)
 	return sb
 }
@@ -818,7 +818,7 @@ func (sb *StunBar) draw(layerno int16, ref int, sbr *StunBar, f []*Fnt) {
 		sb.value.lay.DrawText(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), sys.lifebarScale,
 			layerno, text, f[sb.value.font[0]], sb.value.font[1], sb.value.font[2], sb.value.palfx, sb.value.frgba)
 	}
-	if power > float32(sb.warn_val)/100 {
+	if power > float32(sb.warn_range[0])/100 && power < float32(sb.warn_range[1])/100 {
 		sb.warn.DrawScaled(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), layerno, sys.lifebarScale)
 	}
 	sb.top.DrawScaled(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), layerno, sys.lifebarScale)

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1830,11 +1830,23 @@ func (ro *LifeBarRound) act() bool {
 			}
 			switch sys.finish {
 			case FT_KO:
+				ro.ko_top.Action()
 				f(&ro.ko, 2)
+				for i := len(ro.ko_bg) - 1; i >= 0; i-- {
+					ro.ko_bg[i].Action()
+				}
 			case FT_DKO:
+				ro.dko_top.Action()
 				f(&ro.dko, 2)
+				for i := len(ro.dko_bg) - 1; i >= 0; i-- {
+					ro.dko_bg[i].Action()
+				}
 			default:
+				ro.to_top.Action()
 				f(&ro.to, 2)
+				for i := len(ro.to_bg) - 1; i >= 0; i-- {
+					ro.to_bg[i].Action()
+				}
 			}
 			if sys.intro < -(ro.over_hittime + ro.over_waittime + ro.over_wintime) {
 				if /*sys.finish == FT_DKO ||*/ sys.finish == FT_TODraw {


### PR DESCRIPTION
Added the following optional background and top layer rendering functionality to "round_default", "round_final", "fight", "ko", "dko", "to", "draw", "win", "win2", "win3" and "win4":

- **round.default.top:** top layer feature; allows sprite or animation displayed on top of the round.default, roundX, and round.default.bgX (see below) layers. layerno is enabled for this layer but is always rendered last in its respective stack. 
- **round.default.bgX:** where X is a number 0-32. allows sprite or animation displayed under the round.default and roundX layers. Additionally, layerno is enabled for these layers, enabling rendering of animations/sprites in the background or foreground to achieve complex effects (i.e. wrapping around characters). 

These layers do **not** support the "displaytime" argument: in other words, the round.default.bgX layers are reset when round.default and roundX (as applicable) have reached their displaytime, or when callfight is triggered.

The rendering order is as follows:

round.default.bg0
...
round.default.bg32
round.default
roundX
round.default.top

This same functionality was added to "round_final", "fight", "ko", "dko", "to", "draw", "win", "win2", "win3" and "win4", thereby enabling the following:
- round.final.bgX
- round.final.top
- fight.bgX
- fight.top
- ko.bgX
- ko.top
- dko.bgX
- dko.top
- to.bgX
- to.top
- draw.bgX
- draw.top
- win.bgX
- win.top
- win2.bgX
- win2.top
- win3.bgX
- win3.top
- win4.bgX
- win4.top

The rendering order for these is similar to the round layering, e.g.:

fight.bg0
...
fight.bg32
fight
fight.top

These layers do **not** support the "displaytime" argument: in other words, the win.bgX layers are reset when win.displaytime is met.

Of note, during bug-fixing of round.final and round.default elements being displayed at the same time, logic was included to render round.final.bgX, round.final and round.final.top instead of round.default.bgX, round.default and round.default.top, when appropriate. Any combination is allowable. For example, a user may define round.final.top and round.final but not round.final.bgX, and in a final round round.final.top would be rendered over round.final and round.default.bgX.

These edits have been tested and verified. I can create new dependencies to reflect the new functionality.

EDIT: Also made minor changes to action.zss to enable team-specific spr/anim's for actions. Current implementation does not impact the default setup, but new spr/anims can be defined in common.const based on TeamSide value.

EDIT: [Guardbar] and [Stunbar] pX.front<val> bugs have been fixed.

EDIT: Created new [Lifebar], [Guardbar] and [Stunbar] functionality: pX.warn.range (integer pair interpreted as percentages of the bar) and pX.warn (animation layer). Displays the 'warn' animation layer once the life, guard points or stun points are within pX.warn.range.

For example, to display animation 6 when the whichever bar is between 20% and 1% (i.e. nearly depleted for life or guard):

p1.warn.range = 20,1
p1.warn.anim = 6
p1.warn.offfset = 0,0
p1.warn.layerno = 0
p1.warn.facing = 1
p1.warn.vfacing = 1

EDIT: Fixed a bug in start.lua to enable strings in the 'stage.text' function, and liberal use of %i and %s in the string argument.