### PR TITLE
add Makefile

### DIFF
--- a/Make.linux
+++ b/Make.linux
@@ -1,0 +1,2 @@
+TARG=Ikemen_GO_test
+GOFLAGS=

--- a/Make.macos
+++ b/Make.macos
@@ -1,0 +1,2 @@
+TARG=Ikemen_GO_test
+GOFLAGS=

--- a/Make.ubuntu
+++ b/Make.ubuntu
@@ -1,0 +1,2 @@
+TARG=Ikemen_GO_test
+GOFLAGS=-tags al_cmpt

--- a/Make.windows
+++ b/Make.windows
@@ -1,0 +1,2 @@
+TARG=Ikemen_GO_test.exe
+GOFLAGS=-ldflags "-H windowsgui"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,102 @@
+.POSIX:
+.SUFFIXES:
+.PHONY: all clean cross pkg
+
+CROSS=Ikemen_GO_Linux Ikemen_GO_MacOS Ikemen_GO.exe Ikemen_GO_x86.exe
+ZIP=${CROSS} data external font sound License.txt SoftOpenAL32.dll SoftOpenAL64.dll
+SCREENPACK=elecbyte/chars elecbyte/data elecbyte/font elecbyte/stages
+
+GOFILES=src/anim.go\
+	src/bgdef.go\
+	src/bytecode.go\
+	src/camera.go\
+	src/char.go\
+	src/common.go\
+	src/compiler.go\
+	src/font.go\
+	src/image.go\
+	src/input.go\
+	src/lifebar.go\
+	src/main.go\
+	src/render.go\
+	src/script.go\
+	src/sound.go\
+	src/stage.go\
+	src/stdout_windows.go\
+	src/system.go
+
+include Make.${CONF}
+
+all: ${TARG}
+
+Ikemen_GO_test: ${GOFILES}
+	go build ${GOFLAGS} -o $@ ./src
+
+Ikemen_GO_test.exe: ${GOFILES}
+	go build ${GOFLAGS} -o $@ ./src
+
+
+# cross-compiling from Linux
+Ikemen_GO_Linux: ${GOFILES}
+	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
+	go build ${GOFLAGS} -o $@ ./src
+
+Ikemen_GO_MacOS: ${GOFILES}
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 \
+	CC=o64-clang \
+	CXX=o64-clang++ \
+	go build -tags al_cmpt -o $@ ./src
+
+Ikemen_GO.exe: ${GOFILES} windres/Ikemen_Cylia_x64.syso
+	cp 'windres/Ikemen_Cylia_x64.syso' 'src/Ikemen_Cylia_x64.syso'
+	CGO_ENABLED=1 GOOS=windows GOARCH=amd64 \
+	CC=x86_64-w64-mingw32-gcc \
+	CXX=x86_64-w64-mingw32-g++ \
+	go build -ldflags '-H windowsgui' -o $@ ./src
+	rm 'src/Ikemen_Cylia_x64.syso'
+
+Ikemen_GO_x86.exe: ${GOFILES} windres/Ikemen_Cylia_x86.syso
+	cp 'windres/Ikemen_Cylia_x86.syso' 'src/Ikemen_Cylia_x86.syso'
+	CGO_ENABLED=1 GOOS=windows GOARCH=386 \
+	CC=i686-w64-mingw32-gcc \
+	CXX=i686-w64-mingw32-g++ \
+	go build -ldflags '-H windowsgui' -o $@ ./src
+	rm 'src/Ikemen_Cylia_x86.syso'
+
+cross: ${CROSS}
+
+
+# zip packing
+save save/replays sound:
+	mkdir -p $@
+
+elecbyte:
+	git clone https://github.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack.git elecbyte
+
+SoftOpenAL32.dll:
+	curl -sSLfO https://github.com/ikemen-engine/go-openal/raw/master/openal/lib/SoftOpenAL32.dll
+
+SoftOpenAL64.dll:
+	curl -sSLfO https://github.com/ikemen-engine/go-openal/raw/master/openal/lib/SoftOpenAL64.dll
+
+Ikemen_GO_CoreOnly.zip: ${CROSS} ${ZIP} build/Ikemen_GO.command
+	mkdir -p Ikemen_GO_CoreOnly
+	cp -r ${ZIP} Ikemen_GO_CoreOnly
+	cp build/Ikemen_GO.command Ikemen_GO_CoreOnly/Ikemen_GO.command
+	rm -f $@
+	7z a -tzip $@ Ikemen_GO_CoreOnly
+	rm -r Ikemen_GO_CoreOnly
+
+Ikemen_GO.zip: ${CROSS} ${ZIP} elecbyte build/Ikemen_GO.command
+	mkdir -p Ikemen_GO
+	cp -r ${ZIP} ${SCREENPACK} Ikemen_GO
+	cp build/Ikemen_GO.command Ikemen_GO/Ikemen_GO.command
+	cp elecbyte/LICENCE.txt Ikemen_GO/ScreenpackLicense.txt
+	rm -f $@
+	7z a -tzip $@ Ikemen_GO
+	rm -r Ikemen_GO
+
+pkg: Ikemen_GO_CoreOnly.zip Ikemen_GO.zip
+
+clean:
+	rm -rf Ikemen_GO* elecbyte SoftOpenAL32.dll SoftOpenAL64.dll save


### PR DESCRIPTION
This patch adds a Makefile for building the executable files and zip files.
Invocation looks like this:
`CONF=linux make pkg`
Or on Ubuntu (to add the al_cmpt tag):
`CONF=ubuntu make pkg`

This produces nearly-identical zip files to release 0.97.0, with the following differences:
 * All files are within a top directory.
 * The save directory is not included.

Building individual files is easy. Just specify the filename.
`CONF=ubuntu make Ikemen_GO.exe`
`CONF=ubuntu make Ikemen_GO_CoreOnly.zip`
This can be used to separate build steps in the CI script, as you seem to prefer.

This obsoletes the following files, which can be removed once the CI is changed to use the Makefile.
 * build/build.sh
 * build/build.cmd
 * build/pack_release.sh
 * build/get.cmd
 * build/get.sh
 * build/docker_build.sh
 * move build/Ikemen_GO.command to the top level (modify the Makefile), and remove the build directory

Closes #266
