### PR TITLE
Add "screenshot()" function to LUA

### DIFF
--- a/src/script.go
+++ b/src/script.go
@@ -1605,6 +1605,10 @@ func systemScriptInit(l *lua.LState) {
 		sys.roundResetFlg = true
 		return 0
 	})
+	luaRegister(l, "screenshot", func(*lua.LState) int {
+		captureScreen()
+		return 0
+	})
 	luaRegister(l, "searchFile", func(l *lua.LState) int {
 		var dirs []string
 		tableArg(l, 2).ForEach(func(key, value lua.LValue) {


### PR DESCRIPTION
This PR adds a `screenshot()` function to IKEMEN's LUA functions, to allow for the ability for scripts to take screenshots without the user having to manually press F12.  It does this by invoking the already-existing `captureScreen()` function on the Go side of things.

This is useful for automation, e.g. loading a stage, taking a screenshot of the stage, and then closing the game.