### PR TITLE
Add palfx parameters to Explod/ModifyExplod

### DIFF
--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -677,6 +677,9 @@ func (c *Compiler) explodSub(is IniSection,
 	if err := c.paramTrans(is, sc, "", explod_trans, false); err != nil {
 		return err
 	}
+	if err := c.palFXSub(is, sc, "palfx."); err != nil {
+		return err
+	}
 	return nil
 }
 func (c *Compiler) explod(is IniSection, sc *StateControllerBase,


### PR DESCRIPTION
#407 
This PR adds palfx parameters to Explod/ModifyExplod similar to the parameters in hitdef. It works for both character's anim and fightfx's anim. The ownpal of the explod need to be set to 1 when using the palfx parameters.
Example code using the parameters.
```
Explod{
	anim:6000;
	Id:6000;
	pos:0,0;
	bindid:id;
	bindtime:-1;
	facing:facing;
	sprpriority:3;
	ownpal:1;
	ignorehitpause:0;
	palfx.time:10;
	palfx.mul:256,256,0;
}
```
It is useful for creating color changing explods, especially when the explods need to have ignorehitpause = 0.
