### PR TITLE
fix Explod transparency bug

### DIFF
--- a/src/render.go
+++ b/src/render.go
@@ -97,7 +97,7 @@ func RenderInit() {
 		"if(neg) c.rgb = vec3(1.0 * c.a) - c.rgb;" +
 		"c.rgb += (vec3((c.r + c.g + c.b) / 3.0) - c.rgb) * gray + add * c.a;" +
 		"c.rgb *= mul;" +
-		"c.a *= a;" +
+		"c *= vec4(a);" +
 		"gl_FragColor = c;" +
 		"}\x00"
 	fragShaderFcS := "uniform float a;" +
@@ -488,7 +488,11 @@ func rmMainSub(a int32, size [2]uint16, x, y float32, tl *[4]int32,
 	case trans <= 0:
 	case trans < 255:
 		gl.Uniform1fARB(a, float32(trans)/255)
-		gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
+		if renderMode == 1 {
+			gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
+		} else {
+			gl.BlendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
+		}
 		gl.BlendEquation(gl.FUNC_ADD)
 		rmTileSub(size[0], size[1], x, y, tl, renderMode, xts, xbs, ys, vs, rxadd,
 			agl, yagl, xagl, rcx, rcy)
@@ -520,7 +524,12 @@ func rmMainSub(a int32, size [2]uint16, x, y float32, tl *[4]int32,
 				xagl = 0
 			}
 			gl.Uniform1fARB(a, float32(src)/255)
-			gl.BlendFunc(gl.SRC_ALPHA, gl.ONE)
+
+			if renderMode == 1 {
+				gl.BlendFunc(gl.SRC_ALPHA, gl.ONE)
+			} else {
+				gl.BlendFunc(gl.ONE, gl.ONE)
+			}
 			gl.BlendEquation(gl.FUNC_ADD)
 			rmTileSub(size[0], size[1], x, y, tl, renderMode, xts, xbs, ys, vs, rxadd,
 				agl, yagl, xagl, rcx, rcy)


### PR DESCRIPTION
This commit changed the shader and the rendering function to fix the problem where the image color is multiplied by the image alpha twice. 