### PR TITLE
Add perspective projection

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -656,7 +656,7 @@ func (a *Animation) drawSub1(angle, facing float32) (h, v, agl float32) {
 	return
 }
 func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
-	rxadd, angle, yangle, xangle, rcx float32, pfx *PalFX, old bool, facing float32, isReflection bool, posLocalscl float32) {
+	rxadd, angle, yangle, xangle, rcx float32, pfx *PalFX, old bool, facing float32, isReflection bool, posLocalscl float32, projectionMode int32, fLength float32) {
 	if a.spr == nil || a.spr.Tex == nil {
 		return
 	}
@@ -706,16 +706,18 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 	} else {
 		rcx, rcy = (x+rcx)*sys.widthScale, y*sys.heightScale
 		x, y = AbsF(xs)*float32(a.spr.Offset[0]), AbsF(ys)*float32(a.spr.Offset[1])
+		fLength *= ycs
 	}
 	trans := a.alpha()
 	pal, paltex := a.pal(pfx, trans == -2)
 	a.spr.glDraw(pal, int32(a.mask), x*sys.widthScale,
 		y*sys.heightScale, &a.tile, xs*sys.widthScale, xcs*xbs*h*sys.widthScale,
 		ys*sys.heightScale, xcs*rxadd*sys.widthScale/sys.heightScale, angle, yangle, xangle,
-		trans, window, rcx, rcy, pfx, paltex)
+		trans, window, rcx, rcy, pfx, paltex, projectionMode, fLength*sys.heightScale,
+		xs*posLocalscl*(float32(a.frames[a.drawidx].X)+a.interpolate_offset_x)*a.start_scale[0]*(1/a.scale_x)*sys.widthScale, ys*posLocalscl*(float32(a.frames[a.drawidx].Y)+a.interpolate_offset_y)*a.start_scale[1]*(1/a.scale_y)*sys.heightScale)
 }
 func (a *Animation) ShadowDraw(x, y, xscl, yscl, vscl, angle, yangle, xangle float32,
-	pfx *PalFX, old bool, color uint32, alpha int32, facing float32, posLocalscl float32) {
+	pfx *PalFX, old bool, color uint32, alpha int32, facing float32, posLocalscl float32, projectionMode int32, fLength float32) {
 	if a.spr == nil || a.spr.Tex == nil {
 		return
 	}
@@ -731,7 +733,8 @@ func (a *Animation) ShadowDraw(x, y, xscl, yscl, vscl, angle, yangle, xangle flo
 				AbsF(yscl*v)*float32(a.spr.Offset[1])*sys.heightScale, &a.tile,
 				xscl*h*sys.widthScale, xscl*h*sys.widthScale,
 				yscl*v*sys.heightScale, vscl, 0, angle, yangle, xangle, trans, &sys.scrrect,
-				(x+float32(sys.gameWidth)/2)*sys.widthScale, y*sys.heightScale, color)
+				(x+float32(sys.gameWidth)/2)*sys.widthScale, y*sys.heightScale, color, projectionMode, fLength,
+				xscl*posLocalscl*h*(float32(a.frames[a.drawidx].X)+a.interpolate_offset_x)*(1/a.scale_x), yscl*posLocalscl*vscl*v*(float32(a.frames[a.drawidx].Y)+a.interpolate_offset_y)*(1/a.scale_x))
 		}
 	} else {
 		var pal [256]uint32
@@ -746,7 +749,8 @@ func (a *Animation) ShadowDraw(x, y, xscl, yscl, vscl, angle, yangle, xangle flo
 				AbsF(yscl*v)*float32(a.spr.Offset[1])*sys.heightScale, &a.tile,
 				xscl*h*sys.widthScale, xscl*h*sys.widthScale,
 				yscl*v*sys.heightScale, vscl, 0, angle, yangle, xangle, trans, &sys.scrrect,
-				(x+float32(sys.gameWidth)/2)*sys.widthScale, y*sys.heightScale)
+				(x+float32(sys.gameWidth)/2)*sys.widthScale, y*sys.heightScale, projectionMode, fLength,
+				xscl*posLocalscl*h*(float32(a.frames[a.drawidx].X)+a.interpolate_offset_x)*(1/a.scale_x), yscl*posLocalscl*vscl*v*(float32(a.frames[a.drawidx].Y)+a.interpolate_offset_y)*(1/a.scale_x))
 		}
 	}
 	if color != 0 {
@@ -817,6 +821,8 @@ type SprData struct {
 	oldVer      bool
 	facing      float32
 	posLocalscl float32
+	projection  int32
+	fLength     float32
 }
 type DrawList []*SprData
 
@@ -871,7 +877,7 @@ func (dl DrawList) draw(x, y, scl float32) {
 					(y - s.pos[1])}
 		}
 		s.anim.Draw(&sys.scrrect, p[0], p[1], cs, cs, s.scl[0], s.scl[0],
-			s.scl[1], 0, s.angle, s.yangle, s.xangle, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, false, s.posLocalscl)
+			s.scl[1], 0, s.angle, s.yangle, s.xangle, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, false, s.posLocalscl, s.projection, s.fLength)
 		sys.brightness = ob
 	}
 }
@@ -933,7 +939,7 @@ func (sl ShadowList) draw(x, y, scl float32) {
 			sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-
 				(y+s.pos[1]*sys.stage.sdw.yscale-s.offsetY)*scl,
 			scl*s.scl[0], scl*-s.scl[1], sys.stage.sdw.yscale, s.angle, s.yangle, s.xangle,
-			&sys.bgPalFX, s.oldVer, uint32(color), intensity, s.facing, s.posLocalscl)
+			&sys.bgPalFX, s.oldVer, uint32(color), intensity, s.facing, s.posLocalscl, s.projection, s.fLength)
 	}
 }
 func (sl ShadowList) drawReflection(x, y, scl float32) {
@@ -956,7 +962,7 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 		s.anim.Draw(&sys.scrrect, sys.cam.Offset[0]/scl-(x-s.pos[0]),
 			(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/scl-
 				(y+s.pos[1]-s.offsetY), scl, scl, s.scl[0], s.scl[0], -s.scl[1], 0,
-			s.angle, s.yangle, s.xangle, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, true, s.posLocalscl)
+			s.angle, s.yangle, s.xangle, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, true, s.posLocalscl, s.projection, s.fLength)
 	}
 }
 
@@ -1017,7 +1023,7 @@ func (a *Anim) Draw() {
 	if !sys.frameSkip {
 		a.anim.Draw(&a.window, a.x+float32(sys.gameWidth-320)/2,
 			a.y+float32(sys.gameHeight-240), 1, 1, a.xscl, a.xscl, a.yscl,
-			0, 0, 0, 0, 0, a.palfx, false, 1, false, 1)
+			0, 0, 0, 0, 0, a.palfx, false, 1, false, 1, 0, 0)
 	}
 }
 func (a *Anim) ResetFrames() {

--- a/src/char.go
+++ b/src/char.go
@@ -121,6 +121,14 @@ const (
 	Space_screen
 )
 
+type Projection int32
+
+const (
+	Projection_Orthographic Projection = iota
+	Projection_Perspective
+	Projection_Perspective2
+)
+
 type SaveData int32
 
 const (
@@ -160,7 +168,7 @@ func (cr ClsnRect) draw(trans int32) {
 		RenderMugen(*sys.clsnSpr.Tex, sys.clsnSpr.Pal, -1, sys.clsnSpr.Size,
 			-c[0]*sys.widthScale, -c[1]*sys.heightScale, &notiling,
 			c[2]*sys.widthScale, c[2]*sys.widthScale, c[3]*sys.heightScale, 1, 0, 0, 0, 0,
-			trans, &sys.scrrect, 0, 0)
+			trans, &sys.scrrect, 0, 0, 0, 0, 0, 0)
 	}
 }
 
@@ -745,6 +753,8 @@ type aimgImage struct {
 	angle          float32
 	yangle         float32
 	xangle         float32
+	projection     int32
+	fLength        float32
 	oldVer         bool
 }
 
@@ -867,6 +877,8 @@ func (ai *AfterImage) recAfterImg(sd *SprData, hitpause bool) {
 		img.angle = sd.angle
 		img.yangle = sd.yangle
 		img.xangle = sd.xangle
+		img.projection = sd.projection
+		img.fLength = sd.fLength
 		img.ascl = sd.ascl
 		img.oldVer = sd.oldVer
 		ai.imgidx = (ai.imgidx + 1) & 63
@@ -892,7 +904,7 @@ func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool) {
 			ai.palfx[i/ai.framegap-1].remap = sd.fx.remap
 			sys.sprites.add(&SprData{&img.anim, &ai.palfx[i/ai.framegap-1], img.pos,
 				img.scl, ai.alpha, sd.priority - 2, img.angle, img.yangle, img.xangle, img.ascl,
-				false, sd.bright, sd.oldVer, sd.facing, sd.posLocalscl}, 0, 0, 0, 0)
+				false, sd.bright, sd.oldVer, sd.facing, sd.posLocalscl, img.projection, img.fLength}, 0, 0, 0, 0)
 		}
 	}
 	if rec || hitpause && ai.ignorehitpause {
@@ -931,6 +943,8 @@ type Explod struct {
 	angle          float32
 	yangle         float32
 	xangle         float32
+	projection     Projection
+	fLength        float32
 	oldPos         [2]float32
 	newPos         [2]float32
 	palfx          *PalFX
@@ -941,7 +955,8 @@ type Explod struct {
 func (e *Explod) clear() {
 	*e = Explod{id: IErr, scale: [...]float32{1, 1}, removetime: -2,
 		postype: PT_P1, relativef: 1, facing: 1, vfacing: 1, localscl: 1, space: Space_none,
-		alpha: [...]int32{-1, 0}, playerId: -1, bindId: -2, ignorehitpause: true}
+		projection: Projection_Orthographic,
+		alpha:      [...]int32{-1, 0}, playerId: -1, bindId: -2, ignorehitpause: true}
 }
 func (e *Explod) setX(x float32) {
 	e.pos[0], e.oldPos[0], e.newPos[0] = x, x, x
@@ -1135,10 +1150,16 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	if sdwalp < 0 {
 		sdwalp = 256
 	}
+
+	fLength := e.fLength
+	if fLength <= 0 {
+		fLength = 2048
+	}
+	fLength = fLength * e.localscl
 	var epos = [2]float32{e.pos[0] * e.localscl, e.pos[1] * e.localscl}
 	sprs.add(&SprData{e.anim, pfx, epos, [...]float32{e.facing * e.scale[0] * e.localscl,
 		e.vfacing * e.scale[1] * e.localscl}, alp, e.sprpriority, agl, yagl, xagl, [...]float32{1, 1},
-		screen, playerNo == sys.superplayer, oldVer, e.facing, 1},
+		screen, playerNo == sys.superplayer, oldVer, e.facing, 1, int32(e.projection), fLength},
 		e.shadow[0]<<16|e.shadow[1]&0xff<<8|e.shadow[0]&0xff, sdwalp, 0, 0)
 	if sys.tickNextFrame() {
 		if e.bindtime > 0 {
@@ -1162,7 +1183,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		//		}
 		//	}
 		//}
-		if act {		
+		if act {
 			if e.palfx != nil && e.ownpal {
 				e.palfx.step()
 			}
@@ -1440,7 +1461,7 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 		sd := &SprData{p.ani, p.palfx, [...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl},
 			[...]float32{p.facing * p.scale[0] * p.localscl, p.scale[1] * p.localscl}, [2]int32{-1},
 			p.sprpriority, p.facing * p.angle, 0, 0, [...]float32{1, 1}, false, playerNo == sys.superplayer,
-			sys.cgi[playerNo].ver[0] != 1, p.facing, 1}
+			sys.cgi[playerNo].ver[0] != 1, p.facing, 1, 0, 0}
 		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false)
 		sys.sprites.add(sd,
 			p.shadow[0]<<16|p.shadow[1]&255<<8|p.shadow[2]&255, 256, 0, 0)
@@ -2930,7 +2951,7 @@ func (c *Char) roundState() int32 {
 		return 1
 	case sys.intro >= 0 || sys.finish == FT_NotYet:
 		return 2
-	case sys.intro < -(sys.lifebar.ro.over_hittime+
+	case sys.intro < -(sys.lifebar.ro.over_hittime +
 		sys.lifebar.ro.over_waittime):
 		return 4
 	default:
@@ -3350,6 +3371,11 @@ func (c *Char) newExplod() (*Explod, int) {
 	explinit := func(expl *Explod) *Explod {
 		expl.clear()
 		expl.id, expl.playerId, expl.palfx, expl.palfxdef = -1, c.id, c.getPalfx(), PalFXDef{color: 1, mul: [...]int32{256, 256, 256}}
+		if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 1 && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
+			expl.projection = Projection_Perspective
+		} else {
+			expl.projection = Projection_Orthographic
+		}
 		return expl
 	}
 	for i := range sys.explods[c.playerNo] {
@@ -5729,7 +5755,7 @@ func (c *Char) cueDraw() {
 		sdf := func() *SprData {
 			sd := &SprData{c.anim, c.getPalfx(), pos,
 				scl, c.alpha, c.sprPriority, agl, 0, 0, c.angleScalse, false,
-				c.playerNo == sys.superplayer, c.gi().ver[0] != 1, c.facing, c.localscl / (320 / float32(c.localcoord))}
+				c.playerNo == sys.superplayer, c.gi().ver[0] != 1, c.facing, c.localscl / (320 / float32(c.localcoord)), 0, 0}
 			if !c.sf(CSF_trans) {
 				sd.alpha[0] = -1
 			}

--- a/src/common.go
+++ b/src/common.go
@@ -637,7 +637,7 @@ func (l *Layout) DrawAnim(r *[4]int32, x, y, scl float32, ln int16,
 		a.Draw(r, x+l.offset[0], y+l.offset[1]+float32(sys.gameHeight-240),
 			scl, scl, l.scale[0]*float32(l.facing), l.scale[0]*float32(l.facing),
 			l.scale[1]*float32(l.vfacing), 0, l.angle, 0, 0,
-			float32(sys.gameWidth-320)/2, palfx, false, 1, false, 1)
+			float32(sys.gameWidth-320)/2, palfx, false, 1, false, 1, 0, 0)
 	}
 }
 func (l *Layout) DrawText(x, y, scl float32, ln int16, text string,

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3416,6 +3416,30 @@ func (c *Compiler) paramSpace(is IniSection, sc *StateControllerBase,
 	})
 }
 
+func (c *Compiler) paramProjection(is IniSection, sc *StateControllerBase,
+	id byte) error {
+	return c.stateParam(is, "projection", func(data string) error {
+		if len(data) <= 1 {
+			return Error("Value not specified")
+		}
+		var proj Projection
+		if len(data) >= 2 {
+			if strings.ToLower(data[:2]) == "or" {
+				proj = Projection_Orthographic
+			} else if strings.ToLower(data[:2]) == "pe" {
+				if data[len(data)-1] != '2' {
+					proj = Projection_Perspective
+				} else {
+					proj = Projection_Perspective2
+				}
+
+			}
+		}
+		sc.add(id, sc.iToExp(int32(proj)))
+		return nil
+	})
+}
+
 func (c *Compiler) paramSaveData(is IniSection, sc *StateControllerBase,
 	id byte) error {
 	return c.stateParam(is, "savedata", func(data string) error {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -598,6 +598,9 @@ func (c *Compiler) explodSub(is IniSection,
 	if err := c.paramSpace(is, sc, explod_space); err != nil {
 		return err
 	}
+	if err := c.paramProjection(is, sc, explod_projection); err != nil {
+		return err
+	}
 	f := false
 	if err := c.stateParam(is, "vel", func(data string) error {
 		f = true
@@ -725,6 +728,10 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 			explod_xangle, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "focallength",
+			explod_focallength, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if ihp == 0 {
 			sc.add(explod_ignorehitpause, sc.iToExp(0))
 		}
@@ -769,6 +776,10 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 		}
 		if err := c.paramValue(is, sc, "xangle",
 			explod_xangle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "focallength",
+			explod_focallength, VT_Float, 1, false); err != nil {
 			return err
 		}
 		if ihp == 0 {

--- a/src/font.go
+++ b/src/font.go
@@ -483,7 +483,7 @@ func (f *Fnt) drawChar(x, y, xscl, yscl float32, bank, bt int32,
 	spr.glDraw(pal, 0, -x*sys.widthScale,
 		-y*sys.heightScale, &notiling, xscl*sys.widthScale, xscl*sys.widthScale,
 		yscl*sys.heightScale, 0, 0, 0, 0,
-		sys.brightness*255>>8|1<<9, window, 0, 0, nil, nil)
+		sys.brightness*255>>8|1<<9, window, 0, 0, nil, nil, 0, 0, -xscl*float32(spr.Offset[0]), -yscl*float32(spr.Offset[1]))
 	return float32(spr.Size[0]) * xscl
 }
 
@@ -572,8 +572,8 @@ type TextSprite struct {
 	window           [4]int32
 	palfx            *PalFX
 	frgba            [4]float32 //ttf fonts
-	removetime       int32 //text sctrl
-	layerno          int16 //text sctrl
+	removetime       int32      //text sctrl
+	layerno          int16      //text sctrl
 }
 
 func NewTextSprite() *TextSprite {

--- a/src/image.go
+++ b/src/image.go
@@ -927,7 +927,7 @@ func (s *Sprite) readV2(f *os.File, offset int64, datasize uint32) error {
 	f.Seek(offset+4, 0)
 	if s.rle < 0 {
 		format := -s.rle
-		
+
 		var px []byte
 		var rgba *image.RGBA
 		var rect image.Rectangle
@@ -991,7 +991,7 @@ func (s *Sprite) readV2(f *os.File, offset int64, datasize uint32) error {
 }
 func (s *Sprite) glDraw(pal []uint32, mask int32, x, y float32, tile *[4]int32,
 	xts, xbs, ys, rxadd, agl, yagl, xagl float32, trans int32, window *[4]int32,
-	rcx, rcy float32, pfx *PalFX, paltex *Texture) {
+	rcx, rcy float32, pfx *PalFX, paltex *Texture, projectionMode int32, fLength, xOffset, yOffset float32) {
 	if s.Tex == nil {
 		return
 	}
@@ -1004,14 +1004,14 @@ func (s *Sprite) glDraw(pal []uint32, mask int32, x, y float32, tile *[4]int32,
 
 	if s.rle <= -11 {
 		RenderMugenFc(*s.Tex, s.Size, x, y, tile, xts, xbs, ys, 1, rxadd, agl, yagl, xagl,
-			trans, window, rcx, rcy, neg, color, &padd, &pmul)
+			trans, window, rcx, rcy, neg, color, &padd, &pmul, projectionMode, fLength, xOffset, yOffset)
 	} else {
 		//読み込み済みパレットの情報が渡されてるか //Is the loaded palette information passed?
 		if paltex != nil {
 			gl.ActiveTexture(gl.TEXTURE1)
 			gl.BindTexture(gl.TEXTURE_1D, uint32(*paltex))
 			RenderMugenPal(*s.Tex, mask, s.Size, x, y, tile, xts, xbs, ys, 1,
-				rxadd, agl, yagl, xagl, trans, window, rcx, rcy, neg, color, &padd, &pmul)
+				rxadd, agl, yagl, xagl, trans, window, rcx, rcy, neg, color, &padd, &pmul, projectionMode, fLength, xOffset, yOffset)
 			gl.Disable(gl.TEXTURE_1D)
 			return
 		}
@@ -1034,7 +1034,7 @@ func (s *Sprite) glDraw(pal []uint32, mask int32, x, y float32, tile *[4]int32,
 			gl.ActiveTexture(gl.TEXTURE1)
 			gl.BindTexture(gl.TEXTURE_1D, uint32(*s.PalTex))
 			RenderMugenPal(*s.Tex, mask, s.Size, x, y, tile, xts, xbs, ys, 1,
-				rxadd, agl, yagl, xagl, trans, window, rcx, rcy, neg, color, &padd, &pmul)
+				rxadd, agl, yagl, xagl, trans, window, rcx, rcy, neg, color, &padd, &pmul, projectionMode, fLength, xOffset, yOffset)
 			gl.Disable(gl.TEXTURE_1D)
 		} else {
 			gl.Enable(gl.TEXTURE_1D)
@@ -1049,7 +1049,7 @@ func (s *Sprite) glDraw(pal []uint32, mask int32, x, y float32, tile *[4]int32,
 			tmp := append([]uint32{}, pal...)
 			s.paltemp = tmp
 			RenderMugenPal(*s.Tex, mask, s.Size, x, y, tile, xts, xbs, ys, 1,
-				rxadd, agl, yagl, xagl, trans, window, rcx, rcy, neg, color, &padd, &pmul)
+				rxadd, agl, yagl, xagl, trans, window, rcx, rcy, neg, color, &padd, &pmul, projectionMode, fLength, xOffset, yOffset)
 			gl.Disable(gl.TEXTURE_1D)
 		}
 	}
@@ -1066,7 +1066,7 @@ func (s *Sprite) Draw(x, y, xscale, yscale, angle float32, pal []uint32, fx *Pal
 	}
 	s.glDraw(pal, 0, -x*sys.widthScale, -y*sys.heightScale, &notiling,
 		xscale*sys.widthScale, xscale*sys.widthScale, yscale*sys.heightScale, 0, angle, 0, 0,
-		sys.brightness*255>>8|1<<9, window, 0, 0, fx, paltex)
+		sys.brightness*255>>8|1<<9, window, 0, 0, fx, paltex, 0, 0, -xscale*float32(s.Offset[0]), -yscale*float32(s.Offset[1]))
 }
 
 type Sff struct {

--- a/src/stage.go
+++ b/src/stage.go
@@ -402,7 +402,7 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	rect[3] = int32(math.Floor(float64(startrect1 + (float32(rect[3]) * sys.heightScale * wscl[1]) - float32(rect[1]))))
 	bg.anim.Draw(&rect, x, y, sclx, scly, bg.xscale[0]*bgscl*(bg.scalestart[0]+xs)*xs3, xbs*bgscl*(bg.scalestart[0]+xs)*xs3, ys*ys3,
 		xras*x/(AbsF(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1],
-		+0, 0, 0, float32(sys.gameWidth)/2, &sys.bgPalFX, true, 1, false, 1)
+		+0, 0, 0, float32(sys.gameWidth)/2, &sys.bgPalFX, true, 1, false, 1, 0, 0)
 }
 
 type bgCtrl struct {

--- a/src/system.go
+++ b/src/system.go
@@ -1179,7 +1179,7 @@ func (s *System) action(x, y *float32, scl float32) (leftest, rightest,
 	if s.superanim != nil {
 		s.topSprites.add(&SprData{s.superanim, &s.superpmap, s.superpos,
 			[...]float32{s.superfacing, 1}, [2]int32{-1}, 5, 0, 0, 0, [2]float32{},
-			false, true, s.cgi[s.superplayer].ver[0] != 1, 1, 1}, 0, 0, 0, 0)
+			false, true, s.cgi[s.superplayer].ver[0] != 1, 1, 1, 0, 0}, 0, 0, 0, 0)
 		if s.superanim.loopend {
 			s.superanim = nil
 		}


### PR DESCRIPTION
This commit adds two parameters to explod and modifyexplod
```
projection = type_string (string)
    Does nothing when xy angles are 0
    orthographic: the default value when mugen version is not 1.1 or ikemen version is not 0
    perspective: the default value when mugen version is 1.1 and ikemen version is 0, distortion is affected by the position of the sprite relative to the center of the screen.
    perspective2: distortion is affected by the position of the sprite relative to the center of the animation.

focallength = focal_length (float)
    Focal Length of the projection. Does nothing when projection type is not perspective. Scales internally like xy scales so that the explods looks the same under different resolution/loaclcoord/camera zoom values.
    Default value is 2048
```