### PR TITLE
Do not register keyboard state for glfw.KeyUnknown

### DIFF
--- a/src/input.go
+++ b/src/input.go
@@ -590,6 +590,9 @@ func (sk ShortcutKey) Test(k glfw.Key, m glfw.ModifierKey) bool {
 }
 func keyCallback(_ *glfw.Window, key glfw.Key, _ int,
 	action glfw.Action, mk glfw.ModifierKey) {
+	if (key == glfw.KeyUnknown) {
+		return;
+	}
 	switch action {
 	case glfw.Release:
 		sys.keyState[key] = false


### PR DESCRIPTION
Setting `sys.keyState[glfw.KeyUnknown]` to `true` can have undesired side effects. For instance, if a joystick button is unmapped (mapped to -1) and multimedia keys are used to change the system volume, `JoystickState()` may return `true`, triggering an event for a button that was explicitly disabled in the config.