### PR TITLE
Avoid a string replace call in the text printing code

### DIFF
--- a/src/font.go
+++ b/src/font.go
@@ -572,7 +572,7 @@ func (f *Fnt) DrawTtf(txt string, x, y, xscl, yscl float32, align int32,
 		(*window)[2], (*window)[3]}
 
 	f.ttf.SetColor(frgba[0], frgba[1], frgba[2], frgba[3])
-	f.ttf.Printf(x, y, (xscl+yscl)/2, align, blend, win, strings.Replace(txt, "%", "%%", -1)) //x, y, scale, align, blend, window, string, printf args
+	f.ttf.Printf(x, y, (xscl+yscl)/2, align, blend, win, "%s", txt) //x, y, scale, align, blend, window, string, printf args
 }
 
 type TextSprite struct {


### PR DESCRIPTION
This is a more efficient way to print strings that may contain `%`.